### PR TITLE
Have README.md refer to valid FAQ wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Note: Synology users can use WinSCP to gain access/browse to the root where the 
 
 ## FAQ
 
-https://github.com/SickChill/SickChill/wiki/Frequently-Asked-Questions
+https://github.com/SickChill/SickChill/wiki/FAQ's-and-Fixes
 
 ## Wiki
 


### PR DESCRIPTION
It refered to a non-existent FAQ page while the FAQs and fixes page is present and quite useful.