### PR TITLE
Motor Trend from Velocity

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1272,6 +1272,7 @@ MoonTV:Europe/Helsinki
 More Than Movies (UK):Europe/London
 More4:Europe/London
 Motors TV (UK):Europe/London
+Motor Trend:US/Eastern
 Movie Central:Canada/Eastern
 Movie Extra (AU):Australia/Sydney
 Movie Extra (Australia):Australia/Lord_Howe


### PR DESCRIPTION
Velocity rebranded as Motor Trend on 23 Nov 2018, so copied Velocity entry and renamed it, keeping timezone US/Eastern