### PR TITLE
Update of channel NITRO (known before as RTL Nitro)

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1413,6 +1413,8 @@ Niconico:Asia/Tokyo
 Nine (Australia):Australia/Lord_Howe
 Nine Network:Australia/Sydney
 Nippon Television:Asia/Tokyo
+NITRO (DE):Europe/Berlin
+NITRO:Europe/Berlin
 Noggin:US/Eastern
 Nolife:Europe/Paris
 Nollywood Movies (UK):Europe/London
@@ -1603,8 +1605,6 @@ RTL 8:Europe/Amsterdam
 RTL Crime:Europe/Berlin
 RTL II:Europe/Berlin
 RTL Klub:Europe/Budapest
-RTL Nitro (DE):Europe/Berlin
-RTL Nitro:Europe/Berlin
 RTL Passion (DE):Europe/Berlin
 RTL Passion:Europe/Berlin
 RTL TVI:Europe/Brussels

--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -1605,6 +1605,8 @@ RTL 8:Europe/Amsterdam
 RTL Crime:Europe/Berlin
 RTL II:Europe/Berlin
 RTL Klub:Europe/Budapest
+RTL Nitro (DE):Europe/Berlin
+RTL Nitro:Europe/Berlin
 RTL Passion (DE):Europe/Berlin
 RTL Passion:Europe/Berlin
 RTL TVI:Europe/Brussels


### PR DESCRIPTION
RTL Nitro was renamed to NITRO, so timezones file has to be updated to apply correct timezone.

2018-12-30 00:07:02 ThreadPoolExecutor-0_2 :: [abc6aab] Missing time zone for network: NITRO. Check valid network is set in indexer (theTVDB) before filing issue.