### PR TITLE
add Apple TV+

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -191,6 +191,7 @@ Anime OAV:Asia/Tokyo
 Antena 3:Europe/Madrid
 Antenne 2:Europe/Paris
 Apostolic Oneness Network (US):US/Eastern
+Apple TV+:US/Eastern
 Arabic Channel (US):US/Eastern
 Arena:Australia/Sydney
 Argos TV (UK):Europe/London


### PR DESCRIPTION
timezone based on Netflix drop time and other US networks that are mostly as listed US/Eastern