### PR TITLE
Add HBO Max

### DIFF
--- a/sb_network_timezones/network_timezones.txt
+++ b/sb_network_timezones/network_timezones.txt
@@ -939,6 +939,7 @@ HBO Nordic:Europe/Stockholm
 HBO Signature (US):US/Eastern
 HBO2 (US):US/Eastern
 HBO:US/Eastern
+HBO Max:US/Eastern
 HDNet:US/Eastern
 HGTV Canada:Canada/Eastern
 HGTV:US/Eastern


### PR DESCRIPTION
Dunno if this is useful or not but here goes.
Yeah, it's coming in 2020, but I keep getting these:
```2019-12-20 04:35:01 TORNADO :: Missing time zone for network: HBO Max. Check valid network is set in indexer (theTVDB) before filing issue.
```