### PR TITLE
SE: Intelligence (UK)/(2020) (TVDB: 374093)

### DIFF
--- a/scene_exceptions/scene_exceptions.json
+++ b/scene_exceptions/scene_exceptions.json
@@ -3252,6 +3252,12 @@
                 "90 Day Fiancé The Other Way"
             ]
         },  
+        "374093": {
+            "-1": [
+                "Intelligence (UK)",
+                "Intelligence (2020)"
+            ]
+        },  
         "374053": {
             "-1": [
                 "90 Day Fiance Just Landed",


### PR DESCRIPTION
Update scene exceptions to fix validations for
https://thetvdb.com/series/374093-intelligence

This should also provide better disambuguation with:

 - [TheTVDB TV #79508](https://thetvdb.com/series/intelligence)
 - [TheTVDB TV #267260](https://thetvdb.com/series/intelligence-2014)