### PR TITLE
Add 'Network 10' alternative notation

### DIFF
--- a/sc_network_timezones/network_timezones.txt
+++ b/sc_network_timezones/network_timezones.txt
@@ -869,6 +869,7 @@ Nederlandse Publieke Omroep 3:Europe/Amsterdam
 Nelonen:Europe/Helsinki
 Neox:Europe/Madrid
 Netflix:America/New_York
+Network 10:Australia/Lord_Howe
 Network Ten:Australia/Lord_Howe
 New Tang Dynasty TV:America/New_York
 News One:Asia/Karachi


### PR DESCRIPTION
Alternative spelling, currently see all my Network 10 AU shows on sickchill in my local timezone (European)